### PR TITLE
Fix/bug when link and wikilin in same paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ repository.
 ```yaml
 repos:
 -   repo: https://github.com/jb-delafosse/linky_note
-    rev: v0.4.0
+    rev: v0.4.1
     hooks:
       - id: linky_note apply
         args: ['directory-containing-my-markdown']

--- a/linky_note/adapters/markdown/marko_extractor.py
+++ b/linky_note/adapters/markdown/marko_extractor.py
@@ -101,7 +101,8 @@ class MarkoExtractor(IExtractor):
                     if not isinstance(item, Wikilink)
                     else f"[[{item.label}]]"
                     for item in parent
-                )),
+                )
+            ),
         )
 
     def _extract_wikilink(self, element: Wikilink, parent) -> Reference:

--- a/linky_note/adapters/markdown/marko_extractor.py
+++ b/linky_note/adapters/markdown/marko_extractor.py
@@ -96,8 +96,12 @@ class MarkoExtractor(IExtractor):
                 note_path=NotePath(element.dest),
             ),
             context=ReferenceContext(
-                "".join([self.md_renderer.render(item) for item in parent])
-            ),
+                "".join(
+                    self.md_renderer.render(item)
+                    if not isinstance(item, Wikilink)
+                    else f"[[{item.label}]]"
+                    for item in parent
+                )),
         )
 
     def _extract_wikilink(self, element: Wikilink, parent) -> Reference:

--- a/linky_note/adapters/markdown/marko_modifier.py
+++ b/linky_note/adapters/markdown/marko_modifier.py
@@ -65,6 +65,7 @@ class ModifyAst(NoOpRenderer):
 
     def render_document(self, element: Document, note: Note):
         element = self.render_children(element)
+        element.children.append(MarkoBuilder.build_blank_line())
         element.children.append(
             MarkoBuilder.build_heading(2, LINKED_REFERENCE_SECTION_HEADER)
         )

--- a/linky_note/entrypoints/append_linked_references.py
+++ b/linky_note/entrypoints/append_linked_references.py
@@ -96,7 +96,7 @@ def init():
         "Should the title or the filename be considered as the unique key to reference a note ?",
         type=Choice(["title", "filename"], case_sensitive=False),
         show_choices=True,
-        default="title",
+        default="filename",
     )
 
     link_system = typer.prompt(

--- a/linky_note/usecases/config.py
+++ b/linky_note/usecases/config.py
@@ -27,7 +27,7 @@ def _config_from_dict(config_dict: Dict[str, Any]) -> LinkyNoteConfig:
         ),
         reference_by=ReferenceBy(
             config_dict.get(
-                "reference_by", {"reference_by": ModifyConfig.reference_by}
+                "modify_config", {"reference_by": ModifyConfig.reference_by}
             )["reference_by"]
         ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "linky-note"
-version = "0.4.0"
+version = "0.4.1"
 description = "Awesome `linky-note` is a Python cli/package created with https://github.com/TezRomacH/python-package-template"
 readme = "README.md"
 authors = [

--- a/tests/unit_tests/adapters/mardown/test_marko_modifier.py
+++ b/tests/unit_tests/adapters/mardown/test_marko_modifier.py
@@ -56,7 +56,7 @@ def test_marko_modifier_nominal_link_system(build_ast, mocked_db):
     modified_ast = modifier.modify_ast(ast, source_note)
 
     # Then
-    assert len(modified_ast.children[9].children[0].children) == 2
+    assert len(modified_ast.children[10].children[0].children) == 2
 
 
 def test_marko_modifier_nominal_wikilink_system(build_ast, mocked_db):


### PR DESCRIPTION
## Description


uncaught error when link and wikilink in same parapgaph
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<details>
  <summary>Understanding Labels and how they impact changelog</summary>

|               **Label**               |  **Title in Releases**  |
|:-------------------------------------:|:----------------------: |
| `enhancement`, `feature`              | 🚀 Features             |
| `bug`, `refactoring`, `bugfix`, `fix` | 🔧 Fixes & Refactoring  |
| `build`, `ci`, `testing`              | 📦 Build System & CI/CD |
| `breaking`                            | 💥 Breaking Changes     |
| `documentation`                       | 📝 Documentation        |
| `dependencies`                        | ⬆️ Dependencies updates  |
</details>


<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/jb-delafosse/linky-note/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/jb-delafosse/linky-note/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
