### PR TITLE
fix(pre-commit): pre-commit def is wrong

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
--   id: linky_note
+-   id: linky-note
     name: Generate Backlink Section in Markdown files
     description: This hook will lint Markdown files and generate a backlink Section
-    entry: linky_note
+    entry: linky-note
     language: python
     types: [markdown]
     pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -56,25 +56,25 @@ Limitations: If using wikilinks, a filename should be the same as it's title
 Considering you already have python available. You can simply add th
 
 ```bash
-pip install --user linky_note
+pip install --user linky-note
 ```
 
 Then you can see all the option of the CLI using
 
 ```bash
-linky_note --help
+linky-note --help
 ```
 
 It is advised to start by configuring the CLI using
 
 ```bash
-linky_note init
+linky-note init
 
 ```
 You can then apply the conversion 
 
 ```bash
-linky_note apply <INPUT_DIR> --output-dir <OUTPUT_DIR> 
+linky-note apply <INPUT_DIR> --output-dir <OUTPUT_DIR> 
 
 ```
 
@@ -92,16 +92,16 @@ repository.
 
 ```yaml
 repos:
--   repo: https://github.com/jb-delafosse/linky_note
-    rev: v0.4.1
+-   repo: https://github.com/jb-delafosse/linky-note
+    rev: v0.4.2
     hooks:
-      - id: linky_note apply
+      - id: linky-note apply
         args: ['directory-containing-my-markdown']
 ```
 and install the hook using `pre-commit install`
 
 
-You should also run `linky init` at the root of your repo to configure linky-note
+You should also run `linky-note init` at the root of your repo to configure linky-note
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "linky-note"
-version = "0.4.1"
+version = "0.4.2"
 description = "Awesome `linky-note` is a Python cli/package created with https://github.com/TezRomacH/python-package-template"
 readme = "README.md"
 authors = [


### PR DESCRIPTION

## Description

It seems linky-note cannot be used as a pre-commit
without this fix. The entrypoint is wrongly
defined

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<details>
  <summary>Understanding Labels and how they impact changelog</summary>

|               **Label**               |  **Title in Releases**  |
|:-------------------------------------:|:----------------------: |
| `enhancement`, `feature`              | 🚀 Features             |
| `bug`, `refactoring`, `bugfix`, `fix` | 🔧 Fixes & Refactoring  |
| `build`, `ci`, `testing`              | 📦 Build System & CI/CD |
| `breaking`                            | 💥 Breaking Changes     |
| `documentation`                       | 📝 Documentation        |
| `dependencies`                        | ⬆️ Dependencies updates  |
</details>


<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/jb-delafosse/linky-note/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/jb-delafosse/linky-note/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
