### PR TITLE
fix(link): some links are urlencoded n times

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ repository.
 ```yaml
 repos:
 -   repo: https://github.com/jb-delafosse/linky-note
-    rev: v0.4.3
+    rev: v0.4.4
     hooks:
       - id: linky-note
         args: ['directory-containing-my-markdown']

--- a/linky_note/adapters/markdown/marko_modifier.py
+++ b/linky_note/adapters/markdown/marko_modifier.py
@@ -50,13 +50,18 @@ class ModifyAst(NoOpRenderer):
             element.children[0].children, element.dest, None
         )
 
+    @staticmethod
+    def _encode_once(dest: str) -> str:
+        decoded = urllib.parse.unquote(dest)
+        return urllib.parse.quote(decoded)
+
     def build_link_or_wikilink(
         self, label: str, dest: str, title: Optional[str] = None
     ):
         if self.config.link_system == LinkSystem.LINK:
             if _is_internal_destination(dest):
                 return MarkoBuilder.build_link(
-                    urllib.parse.quote(dest), label, title
+                    self._encode_once(dest), label, title
                 )
             else:
                 return MarkoBuilder.build_link(dest, label, title)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "linky-note"
-version = "0.4.3"
+version = "0.4.4"
 description = "Awesome `linky-note` is a Python cli/package created with https://github.com/TezRomacH/python-package-template"
 readme = "README.md"
 authors = [

--- a/tests/unit_tests/adapters/mardown/test_marko_modifier.py
+++ b/tests/unit_tests/adapters/mardown/test_marko_modifier.py
@@ -61,7 +61,8 @@ def test_marko_modifier_nominal_link_system(build_ast, mocked_db):
 
 def test_marko_modifier_link_system_url_encode(build_ast, mocked_db):
     # Given
-    # A note referenced by a note whose filename needs to be url encode
+    # - a reference whose filename needs to be url encode
+    # - a reference whose filename is already url endoded
     source_note = Note(
         note_title=NoteTitle("Marketing"), note_path=NotePath("Marketing.md")
     )
@@ -77,6 +78,14 @@ def test_marko_modifier_link_system_url_encode(build_ast, mocked_db):
                 target_note=source_note,
                 context=ReferenceContext(f"A reference to {url}"),
             ),
+            Reference(
+                source_note=Note(
+                    note_title=NoteTitle("Content Marketing"),
+                    note_path=NotePath("content%20marketing.md"),
+                ),
+                target_note=source_note,
+                context=ReferenceContext(f"A reference to {url}"),
+            ),
         )
     )
     modifier = MarkoModifierImpl(mocked_db(returned_value), ModifyConfig())
@@ -87,9 +96,14 @@ def test_marko_modifier_link_system_url_encode(build_ast, mocked_db):
 
     # Then
     # - The link to the reference is URL encoded
+    # - an already url encoded link is not re-encoded
     assert (
         modified_ast.children[10].children[0].children[0].children[0].dest
         == "digital%20marketing.md"
+    )
+    assert (
+        modified_ast.children[10].children[1].children[0].children[0].dest
+        == "content%20marketing.md"
     )
 
 


### PR DESCRIPTION
## Description
yet another problem with Url encoding of links
links are url encoded again and again by linky-note
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<details>
  <summary>Understanding Labels and how they impact changelog</summary>

|               **Label**               |  **Title in Releases**  |
|:-------------------------------------:|:----------------------: |
| `enhancement`, `feature`              | 🚀 Features             |
| `bug`, `refactoring`, `bugfix`, `fix` | 🔧 Fixes & Refactoring  |
| `build`, `ci`, `testing`              | 📦 Build System & CI/CD |
| `breaking`                            | 💥 Breaking Changes     |
| `documentation`                       | 📝 Documentation        |
| `dependencies`                        | ⬆️ Dependencies updates  |
</details>


<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/jb-delafosse/linky-note/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/jb-delafosse/linky-note/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
