### PR TITLE
feat(parser): allow to parse frontmatter

### DIFF
--- a/linky_note/adapters/markdown/factories.py
+++ b/linky_note/adapters/markdown/factories.py
@@ -1,6 +1,5 @@
 from linky_note.adapters.markdown.marko_extractor import MarkoExtractor
 from linky_note.dto.dto import NotePath
-from linky_note.interfaces.reference_extractor import ReferenceExtractorFactory
 
 
 class MarkoExtractorFactory:

--- a/linky_note/adapters/markdown/marko_ext/elements.py
+++ b/linky_note/adapters/markdown/marko_ext/elements.py
@@ -144,7 +144,7 @@ class BacklinkSection(block.BlockElement):
 
     def __init__(self, match):
         self.level = 2
-        self.children = "Linked References"
+        self.children = []
 
     @classmethod
     def match(cls, source):

--- a/linky_note/adapters/markdown/marko_ext/elements.py
+++ b/linky_note/adapters/markdown/marko_ext/elements.py
@@ -3,6 +3,8 @@ from typing import Any, Iterator, List, Match, Optional, Tuple
 import re
 from pathlib import Path
 
+import yaml
+from linky_note.adapters.markdown.marko_ext.marko_builder import MarkoBuilder
 from linky_note.dto.dto import (
     Note,
     NotePath,
@@ -32,6 +34,32 @@ class Wikilink(inline.InlineElement):
             cls.pattern = re.compile(cls.pattern)  # type: ignore
         match_list = [match for match in cls.pattern.finditer(text)]  # type: ignore
         return match_list
+
+
+class FrontMatter(block.BlockElement):
+    pattern = r"^---\n([\s\S]+?)---"
+    priority = 9
+
+    def __init__(self, match):
+        super().__init__()
+        if match:
+            self.children = [MarkoBuilder.build_raw_element(match.group(1))]
+            self.dict = yaml.load(match.group(1), Loader=yaml.SafeLoader)
+        else:
+            self.children = None
+
+    @classmethod
+    def match(cls, source):  # type: (Source) -> bool
+        m = source.expect_re(cls.pattern)
+        if not m:
+            return False
+        return True
+
+    @classmethod
+    def parse(cls, source):  # type: (Source) -> FrontMatter
+        instance = cls(source.match)
+        source.consume()
+        return instance
 
 
 class Wikiimage(inline.InlineElement):

--- a/linky_note/adapters/markdown/marko_modifier.py
+++ b/linky_note/adapters/markdown/marko_modifier.py
@@ -22,36 +22,18 @@ from marko.inline import Link
 LINKED_REFERENCE_SECTION_HEADER = "Linked References"
 
 
-class NoOpRenderer(Renderer):
-    def render_children(self, element):
-        if isinstance(element, list):
-            return [self.render(e) for e in element]
-        if isinstance(element, str):
-            return element
-        rv = deepcopy(element)
-        if hasattr(rv, "children"):
-            rv.children = self.render(rv.children)
-        return rv
-
-
-def _is_internal_destination(dest: str):
-    return dest.endswith(".md")
-
-
-class ModifyAst(NoOpRenderer):
-    def __init__(self, reference_db: IReferenceDB, modify_config: ModifyConfig):
+class ModifierVisitor(Renderer):
+    def __init__(
+        self,
+        reference_db: IReferenceDB,
+        modify_config: ModifyConfig,
+        note: Note,
+    ):
         super().__init__()
         self._reference_db = reference_db
         self.config = modify_config
         self.root = Path("/root")
-
-    def render_wikilink(self, element: Wikilink):
-        return self.build_link_or_wikilink(element.label, element.dest, None)
-
-    def render_link(self, element: Link):
-        return self.build_link_or_wikilink(
-            element.children[0].children, element.dest, None
-        )
+        self.note = note
 
     @staticmethod
     def _encode_once(dest: str) -> str:
@@ -74,30 +56,15 @@ class ModifyAst(NoOpRenderer):
             else:
                 return MarkoBuilder.build_link(dest, label, title)
 
-    def render_backlink_section(self, element: BacklinkSection):
-        return MarkoBuilder.build_raw_element("")
+    def render_wikilink(self, element: Wikilink):
+        return self.build_link_or_wikilink(element.label, element.dest, None)
 
-    def render_document(self, element: Document, note: Note):
-        element = self.render_children(element)
-        element.children.append(MarkoBuilder.build_blank_line())
-        element.children.append(
-            MarkoBuilder.build_heading(2, LINKED_REFERENCE_SECTION_HEADER)
+    def render_link(self, element: Link):
+        return self.build_link_or_wikilink(
+            element.children[0].children, element.dest, None
         )
-        db_response = self._reference_db.get_references_that_targets(
-            references_db.GetReferencesThatTarget(
-                reference=note.note_title
-                if self.config.reference_by == ReferenceBy.TITLE
-                else note.note_path
-            )
-        )
-        if len(db_response.references) > 0:
-            element.children.append(MarkoBuilder.build_blank_line())
 
-            element.children.append(self.build_backlinks(db_response, note))
-        return element
-
-    def build_backlinks(self, db_response, note: Note):
-
+    def _build_backlinks(self, db_response):
         ref_dict = defaultdict(list)
         items_in_backlink_section = []
         for ref in db_response.references:
@@ -107,7 +74,7 @@ class ModifyAst(NoOpRenderer):
             sub_item = []
             rel_path = os.path.relpath(
                 self.root / source_note.note_path,
-                self.root / note.note_path.parent,
+                self.root / self.note.note_path.parent,
             )
             sub_item.append(
                 MarkoBuilder.build_paragraph(
@@ -135,12 +102,86 @@ class ModifyAst(NoOpRenderer):
             )
         return MarkoBuilder.build_list(items_in_backlink_section)
 
-    def render_wikiimage(self, element):
-        raise NotImplementedError()
+    def render_backlinksection(self):
+        element = BacklinkSection("")
+        element.children.append(
+            MarkoBuilder.build_heading(2, LINKED_REFERENCE_SECTION_HEADER)
+        )
+        db_response = self._reference_db.get_references_that_targets(
+            references_db.GetReferencesThatTarget(
+                reference=self.note.note_title
+                if self.config.reference_by == ReferenceBy.TITLE
+                else self.note.note_path
+            )
+        )
+        if len(db_response.references) > 0:
+            element.children.append(MarkoBuilder.build_blank_line())
+            element.children.append(self._build_backlinks(db_response))
+        return element
+
+    def render_list(self, element: list) -> list:
+        return [self.render_children(e) for e in element]
+
+    def render_document(self, element: Document):
+        last_child_is_a_backlink_section = isinstance(
+            element.children[-1], BacklinkSection
+        )
+        if not last_child_is_a_backlink_section:
+            element.children = self.render_list(element.children)
+            element.children.append(self.render_backlinksection())
+            return element
+        else:
+            element.children = self.render_list(element.children)
+            return element
+
+    def render_children(self, element):
+        if isinstance(element, Document):
+            return self.render_document(element)
+        if isinstance(element, BacklinkSection):
+            return self.render_backlinksection()
+        if isinstance(element, list):
+            return self.render_list(element)
+        if isinstance(element, Wikilink):
+            return self.render_wikilink(element)
+        if isinstance(element, Link):
+            return self.render_link(element)
+        if isinstance(element, str):
+            return element
+        rv = deepcopy(element)
+        if hasattr(rv, "children"):
+            rv.children = self.render(rv.children)
+        return rv
+
+
+class ModifierVisitorFactory:
+    def __init__(self, reference_db: IReferenceDB, modify_config: ModifyConfig):
+        self._reference_db = reference_db
+        self.config = modify_config
+        self.root = Path("/root")
+
+    def __call__(self, note: Note) -> ModifierVisitor:
+        return ModifierVisitor(self._reference_db, self.config, note)
+
+
+def _is_internal_destination(dest: str):
+    return dest.endswith(".md")
+
+
+class ModifyAst:
+    def __init__(self, reference_db: IReferenceDB, modify_config: ModifyConfig):
+        super().__init__()
+        self.visitor_factory = ModifierVisitorFactory(
+            reference_db, modify_config
+        )
+
+    def modify_document(self, element: Document, note: Note):
+        visitor = self.visitor_factory(note)
+        element = visitor.render_children(element)
+        return element
 
 
 class MarkoModifierImpl(IModifier):
     def modify_ast(self, ast: Document, note: Note) -> Document:
-        return ModifyAst(self.reference_db, self.modify_config).render_document(
+        return ModifyAst(self.reference_db, self.modify_config).modify_document(
             ast, note
         )

--- a/linky_note/adapters/markdown/marko_parser.py
+++ b/linky_note/adapters/markdown/marko_parser.py
@@ -2,9 +2,9 @@ from pathlib import Path
 
 from linky_note.adapters.markdown.marko_ext.elements import (
     BacklinkSection,
+    FrontMatter,
     Wikiimage,
     Wikilink,
-    FrontMatter
 )
 from linky_note.dto.dto import ParseConfig
 from linky_note.interfaces.parser import IParser

--- a/linky_note/adapters/markdown/marko_parser.py
+++ b/linky_note/adapters/markdown/marko_parser.py
@@ -4,6 +4,7 @@ from linky_note.adapters.markdown.marko_ext.elements import (
     BacklinkSection,
     Wikiimage,
     Wikilink,
+    FrontMatter
 )
 from linky_note.dto.dto import ParseConfig
 from linky_note.interfaces.parser import IParser
@@ -16,6 +17,8 @@ class MarkoParserImpl(IParser):
         self.marko_parser = Parser()
         if parse_config.parse_wikilinks:
             self.marko_parser.add_element(Wikilink)
+        if parse_config.parse_frontmatter:
+            self.marko_parser.add_element(FrontMatter)
         self.marko_parser.add_element(Wikiimage)
         self.marko_parser.add_element(BacklinkSection)
 

--- a/linky_note/dto/dto.py
+++ b/linky_note/dto/dto.py
@@ -44,10 +44,16 @@ class ReferenceBy(str, Enum):
     FILENAME = "filename"
 
 
+class BacklinksLocation(str, Enum):
+    BACKLINK_SECTION = "backlink-section"
+    FRONTMATTER = "frontmatter"
+
+
 @dataclass(frozen=True)
 class ModifyConfig:
     link_system: LinkSystem = LinkSystem.LINK
     reference_by: ReferenceBy = ReferenceBy.TITLE
+    backlinks_location: BacklinksLocation = BacklinksLocation.BACKLINK_SECTION
 
 
 @dataclass(frozen=True)

--- a/linky_note/dto/dto.py
+++ b/linky_note/dto/dto.py
@@ -31,6 +31,7 @@ class ParsedReference:
 @dataclass(frozen=True)
 class ParseConfig:
     parse_wikilinks: bool = True
+    parse_frontmatter: bool = False
 
 
 class LinkSystem(str, Enum):

--- a/tests/e2e/frontmatter/data/0000-use-markdown-architectural-decision-records.md
+++ b/tests/e2e/frontmatter/data/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,35 @@
+---
+backlinks: []
+layout: post
+title: Use Markdown Architectural Decision Records
+---
+* Type: [ADR](adr.md)
+* Status: [Proposed](proposed.md)
+* Deciders: [John](john.md) [Richard](richard.md) [Sophia](sophia.md)
+* Date: 2020-02-01
+* Categorie: [Format](format.md)
+
+## Context and Problem Statement
+
+We want to record architectural decisions made in this project.
+Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 2.1.2 – The Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 2.1.2", because
+
+* Implicit assumptions should be made explicit.
+Design documentation is important to enable people understanding the decisions later on.
+See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+* Version 2.1.2 is the latest one available when starting to document ADRs.

--- a/tests/e2e/frontmatter/data/0001-use-CC0-as-license.md
+++ b/tests/e2e/frontmatter/data/0001-use-CC0-as-license.md
@@ -1,0 +1,26 @@
+---
+backlinks: []
+layout: post
+title: Use CC0 as license
+---
+* Type: [ADR](adr.md)
+* Status: [Accepted](accepted.md)
+* Deciders: [John](john.md)[Sophia](sophia.md)
+* Date: 2020-02-01
+* Categorie: [Legal](legal.md)
+
+Everything needs to be licensed, otherwise the default copyright laws apply.
+For instance, in Germany that means users may not alter anything without explicitly asking for permission.
+For more information see <https://help.github.com/articles/licensing-a-repository/>.
+
+We want to have MADR used without any hassle and that users can just go ahead and write MADRs.
+
+## Considered Options
+
+* [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)
+* No license
+* Other open source licenses
+
+## Decision Outcome
+
+Chosen option: "CC0", because this license donates the content to "public domain" and does so as legally as possible.

--- a/tests/e2e/frontmatter/data/0002-do-not-use-numbers-in-headings.md
+++ b/tests/e2e/frontmatter/data/0002-do-not-use-numbers-in-headings.md
@@ -1,0 +1,27 @@
+---
+backlinks: []
+layout: post
+title: Do not use numbers in headings
+---
+* Type: [ADR](adr.md)
+* Status: [Proposed](proposed.md)
+* Deciders: [John](john.md)[Sophia](sophia.md)
+* Date: 2020-02-01
+* Categorie: [Headings](headings.md)
+
+How to render the first line in an ADR?
+ADRs have to take a unique identifier.
+
+## Considered Options
+
+* Use the title only
+* Add the ADR number in front of the title (e.g., "# 2. Do not use numbers in headings")
+
+## Decision Outcome
+
+Chosen option: Use the title only, because
+
+* This is common in other markdown files, too.
+One does not add numbering manually at the markdown files, but tries to get the numbers injected by the rendering framework or CSS.
+* Enables renaming of ADRs (before publication) easily
+* Allows copy'n'paste of ADRs from other repositories without having to worry about the numbers.

--- a/tests/e2e/frontmatter/data/accepted.md
+++ b/tests/e2e/frontmatter/data/accepted.md
@@ -1,0 +1,12 @@
+---
+backlinks:
+- note_path: 0001-use-CC0-as-license.md
+  note_title: Use CC0 as license
+  references:
+  - 'Status: **Accepted**'
+layout: post
+title: Accepted
+---
+* Type: [Status](status.md)
+
+List all the ADR that are accepted

--- a/tests/e2e/frontmatter/data/adr.md
+++ b/tests/e2e/frontmatter/data/adr.md
@@ -1,0 +1,21 @@
+---
+backlinks:
+- note_path: 0002-do-not-use-numbers-in-headings.md
+  note_title: Do not use numbers in headings
+  references:
+  - 'Type: **ADR**'
+- note_path: 0001-use-CC0-as-license.md
+  note_title: Use CC0 as license
+  references:
+  - 'Type: **ADR**'
+- note_path: 0000-use-markdown-architectural-decision-records.md
+  note_title: Use Markdown Architectural Decision Records
+  references:
+  - 'Type: **ADR**'
+layout: post
+title: ADR
+---
+This log lists the architectural decisions for MADR.
+
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/tests/e2e/frontmatter/data/categorie.md
+++ b/tests/e2e/frontmatter/data/categorie.md
@@ -1,0 +1,18 @@
+---
+backlinks:
+- note_path: format.md
+  note_title: Format
+  references:
+  - 'Type: **Categorie**'
+- note_path: headings.md
+  note_title: Headings
+  references:
+  - 'Type: **Categorie**'
+- note_path: legal.md
+  note_title: Legal
+  references:
+  - 'Type: **Categorie**'
+layout: post
+title: Categorie
+---
+Every category of ADR

--- a/tests/e2e/frontmatter/data/format.md
+++ b/tests/e2e/frontmatter/data/format.md
@@ -1,0 +1,12 @@
+---
+backlinks:
+- note_path: 0000-use-markdown-architectural-decision-records.md
+  note_title: Use Markdown Architectural Decision Records
+  references:
+  - 'Categorie: **Format**'
+layout: post
+title: Format
+---
+* Type: [Categorie](categorie.md)
+
+All ADR about the format

--- a/tests/e2e/frontmatter/data/headings.md
+++ b/tests/e2e/frontmatter/data/headings.md
@@ -1,0 +1,12 @@
+---
+backlinks:
+- note_path: 0002-do-not-use-numbers-in-headings.md
+  note_title: Do not use numbers in headings
+  references:
+  - 'Categorie: **Headings**'
+layout: post
+title: Headings
+---
+* Type: [Categorie](categorie.md)
+
+All ADR about the headings

--- a/tests/e2e/frontmatter/data/john.md
+++ b/tests/e2e/frontmatter/data/john.md
@@ -1,0 +1,20 @@
+---
+backlinks:
+- note_path: 0002-do-not-use-numbers-in-headings.md
+  note_title: Do not use numbers in headings
+  references:
+  - 'Deciders: **John****Sophia**'
+- note_path: 0001-use-CC0-as-license.md
+  note_title: Use CC0 as license
+  references:
+  - 'Deciders: **John****Sophia**'
+- note_path: 0000-use-markdown-architectural-decision-records.md
+  note_title: Use Markdown Architectural Decision Records
+  references:
+  - 'Deciders: **John** **Richard** **Sophia**'
+layout: post
+title: John
+---
+* Type: [Person](person.md)
+
+Everything that relates to John

--- a/tests/e2e/frontmatter/data/legal.md
+++ b/tests/e2e/frontmatter/data/legal.md
@@ -1,0 +1,12 @@
+---
+backlinks:
+- note_path: 0001-use-CC0-as-license.md
+  note_title: Use CC0 as license
+  references:
+  - 'Categorie: **Legal**'
+layout: post
+title: Legal
+---
+* Type: [Categorie](categorie.md)
+
+All ADR about the legal stuff

--- a/tests/e2e/frontmatter/data/person.md
+++ b/tests/e2e/frontmatter/data/person.md
@@ -1,0 +1,18 @@
+---
+backlinks:
+- note_path: john.md
+  note_title: John
+  references:
+  - 'Type: **Person**'
+- note_path: richard.md
+  note_title: Richard
+  references:
+  - 'Type: **Person**'
+- note_path: sophia.md
+  note_title: Sophia
+  references:
+  - 'Type: **Person**'
+layout: post
+title: Person
+---
+A list of all the person that worked on the ADR

--- a/tests/e2e/frontmatter/data/proposed.md
+++ b/tests/e2e/frontmatter/data/proposed.md
@@ -1,0 +1,16 @@
+---
+backlinks:
+- note_path: 0002-do-not-use-numbers-in-headings.md
+  note_title: Do not use numbers in headings
+  references:
+  - 'Status: **Proposed**'
+- note_path: 0000-use-markdown-architectural-decision-records.md
+  note_title: Use Markdown Architectural Decision Records
+  references:
+  - 'Status: **Proposed**'
+layout: post
+title: Proposed
+---
+* Type: [Status](status.md)
+
+List all the ADR that are proposed

--- a/tests/e2e/frontmatter/data/richard.md
+++ b/tests/e2e/frontmatter/data/richard.md
@@ -1,0 +1,12 @@
+---
+backlinks:
+- note_path: 0000-use-markdown-architectural-decision-records.md
+  note_title: Use Markdown Architectural Decision Records
+  references:
+  - 'Deciders: **John** **Richard** **Sophia**'
+layout: post
+title: Richard
+---
+* Type: [Person](person.md)
+
+Everything about Richard

--- a/tests/e2e/frontmatter/data/sophia.md
+++ b/tests/e2e/frontmatter/data/sophia.md
@@ -1,0 +1,20 @@
+---
+backlinks:
+- note_path: 0002-do-not-use-numbers-in-headings.md
+  note_title: Do not use numbers in headings
+  references:
+  - 'Deciders: **John****Sophia**'
+- note_path: 0001-use-CC0-as-license.md
+  note_title: Use CC0 as license
+  references:
+  - 'Deciders: **John****Sophia**'
+- note_path: 0000-use-markdown-architectural-decision-records.md
+  note_title: Use Markdown Architectural Decision Records
+  references:
+  - 'Deciders: **John** **Richard** **Sophia**'
+layout: post
+title: Sophia
+---
+* Type: [Person](person.md)
+
+Everything about Sophia

--- a/tests/e2e/frontmatter/data/status.md
+++ b/tests/e2e/frontmatter/data/status.md
@@ -1,0 +1,14 @@
+---
+backlinks:
+- note_path: accepted.md
+  note_title: Accepted
+  references:
+  - 'Type: **Status**'
+- note_path: proposed.md
+  note_title: Proposed
+  references:
+  - 'Type: **Status**'
+layout: post
+title: Status
+---
+List all the status possible for an ADR

--- a/tests/e2e/frontmatter/test_frontmatter.py
+++ b/tests/e2e/frontmatter/test_frontmatter.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from linky_note.dto.dto import (
+    BacklinksLocation,
+    LinkyNoteConfig,
+    ModifyConfig,
+    ParseConfig,
+)
+from linky_note.infrastructure.cli_app import setup_app
+from tests.e2e.common import check_files_did_not_change, runner
+
+
+def test_frontmatter(working_dir):
+    # Given
+    input_directory = str(working_dir / Path("frontmatter") / Path("data"))
+    output_directory = "/tmp/test-frontmatter"
+    app = setup_app(
+        LinkyNoteConfig(
+            parse_config=ParseConfig(
+                parse_wikilinks=False, parse_frontmatter=True
+            ),
+            modify_config=ModifyConfig(
+                backlinks_location=BacklinksLocation.FRONTMATTER
+            ),
+        )
+    )
+
+    # When
+    result = runner.invoke(
+        app, ["apply", input_directory, "--output-dir", output_directory]
+    )
+
+    # Then
+    assert result.exit_code == 0
+    check_files_did_not_change(Path(input_directory), Path(output_directory))

--- a/tests/e2e/link/data/0000-use-markdown-architectural-decision-records.md
+++ b/tests/e2e/link/data/0000-use-markdown-architectural-decision-records.md
@@ -31,5 +31,4 @@ See also [A rational design process: How and why to fake it](https://doi.org/10.
 * The MADR project is vivid.
 * Version 2.1.2 is the latest one available when starting to document ADRs.
 
-
 ## Linked References

--- a/tests/e2e/link/data/0001-use-CC0-as-license.md
+++ b/tests/e2e/link/data/0001-use-CC0-as-license.md
@@ -22,5 +22,4 @@ We want to have MADR used without any hassle and that users can just go ahead an
 
 Chosen option: "CC0", because this license donates the content to "public domain" and does so as legally as possible.
 
-
 ## Linked References

--- a/tests/e2e/link/data/0002-do-not-use-numbers-in-headings.md
+++ b/tests/e2e/link/data/0002-do-not-use-numbers-in-headings.md
@@ -23,5 +23,4 @@ One does not add numbering manually at the markdown files, but tries to get the 
 * Enables renaming of ADRs (before publication) easily
 * Allows copy'n'paste of ADRs from other repositories without having to worry about the numbers.
 
-
 ## Linked References

--- a/tests/e2e/link/data/accepted.md
+++ b/tests/e2e/link/data/accepted.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are accepted
 
-
 ## Linked References
 
 * [Use CC0 as license](0001-use-CC0-as-license.md)

--- a/tests/e2e/link/data/adr.md
+++ b/tests/e2e/link/data/adr.md
@@ -5,7 +5,6 @@ This log lists the architectural decisions for MADR.
 More information on MADR is available at <https://adr.github.io/madr/>.
 General information about architectural decision records is available at <https://adr.github.io/>.
 
-
 ## Linked References
 
 * [Do not use numbers in headings](0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link/data/categorie.md
+++ b/tests/e2e/link/data/categorie.md
@@ -2,7 +2,6 @@
 
 Every categories of ADR
 
-
 ## Linked References
 
 * [Format](format.md)

--- a/tests/e2e/link/data/format.md
+++ b/tests/e2e/link/data/format.md
@@ -4,7 +4,6 @@
 
 All ADR about the format
 
-
 ## Linked References
 
 * [Use Markdown Architectural Decision Records](0000-use-markdown-architectural-decision-records.md)

--- a/tests/e2e/link/data/headings.md
+++ b/tests/e2e/link/data/headings.md
@@ -4,7 +4,6 @@
 
 All ADR about the headings
 
-
 ## Linked References
 
 * [Do not use numbers in headings](0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link/data/john.md
+++ b/tests/e2e/link/data/john.md
@@ -4,7 +4,6 @@
 
 Everything that relates to John
 
-
 ## Linked References
 
 * [Do not use numbers in headings](0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link/data/legal.md
+++ b/tests/e2e/link/data/legal.md
@@ -4,7 +4,6 @@
 
 All ADR about the legal stuff
 
-
 ## Linked References
 
 * [Use CC0 as license](0001-use-CC0-as-license.md)

--- a/tests/e2e/link/data/person.md
+++ b/tests/e2e/link/data/person.md
@@ -2,7 +2,6 @@
 
 A list of all the person that worked on the ADR
 
-
 ## Linked References
 
 * [John](john.md)

--- a/tests/e2e/link/data/proposed.md
+++ b/tests/e2e/link/data/proposed.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are proposed
 
-
 ## Linked References
 
 * [Do not use numbers in headings](0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link/data/richard.md
+++ b/tests/e2e/link/data/richard.md
@@ -4,7 +4,6 @@
 
 Everything about Richard
 
-
 ## Linked References
 
 * [Use Markdown Architectural Decision Records](0000-use-markdown-architectural-decision-records.md)

--- a/tests/e2e/link/data/sophia.md
+++ b/tests/e2e/link/data/sophia.md
@@ -4,7 +4,6 @@
 
 Everything about Sophia
 
-
 ## Linked References
 
 * [Do not use numbers in headings](0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link/data/status.md
+++ b/tests/e2e/link/data/status.md
@@ -2,7 +2,6 @@
 
 List all the status possible for an ADR
 
-
 ## Linked References
 
 * [Accepted](accepted.md)

--- a/tests/e2e/link_subfolders/data/adr/0000-use-markdown-architectural-decision-records.md
+++ b/tests/e2e/link_subfolders/data/adr/0000-use-markdown-architectural-decision-records.md
@@ -31,5 +31,4 @@ See also [A rational design process: How and why to fake it](https://doi.org/10.
 * The MADR project is vivid.
 * Version 2.1.2 is the latest one available when starting to document ADRs.
 
-
 ## Linked References

--- a/tests/e2e/link_subfolders/data/adr/0001-use-CC0-as-license.md
+++ b/tests/e2e/link_subfolders/data/adr/0001-use-CC0-as-license.md
@@ -22,5 +22,4 @@ We want to have MADR used without any hassle and that users can just go ahead an
 
 Chosen option: "CC0", because this license donates the content to "public domain" and does so as legally as possible.
 
-
 ## Linked References

--- a/tests/e2e/link_subfolders/data/adr/0002-do-not-use-numbers-in-headings.md
+++ b/tests/e2e/link_subfolders/data/adr/0002-do-not-use-numbers-in-headings.md
@@ -23,5 +23,4 @@ One does not add numbering manually at the markdown files, but tries to get the 
 * Enables renaming of ADRs (before publication) easily
 * Allows copy'n'paste of ADRs from other repositories without having to worry about the numbers.
 
-
 ## Linked References

--- a/tests/e2e/link_subfolders/data/adr/adr.md
+++ b/tests/e2e/link_subfolders/data/adr/adr.md
@@ -5,7 +5,6 @@ This log lists the architectural decisions for MADR.
 More information on MADR is available at <https://adr.github.io/madr/>.
 General information about architectural decision records is available at <https://adr.github.io/>.
 
-
 ## Linked References
 
 * [Do not use numbers in headings](0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link_subfolders/data/categorie/categorie.md
+++ b/tests/e2e/link_subfolders/data/categorie/categorie.md
@@ -2,7 +2,6 @@
 
 Every categories of ADR
 
-
 ## Linked References
 
 * [Format](format.md)

--- a/tests/e2e/link_subfolders/data/categorie/format.md
+++ b/tests/e2e/link_subfolders/data/categorie/format.md
@@ -4,7 +4,6 @@
 
 All ADR about the format
 
-
 ## Linked References
 
 * [Use Markdown Architectural Decision Records](../adr/0000-use-markdown-architectural-decision-records.md)

--- a/tests/e2e/link_subfolders/data/categorie/headings.md
+++ b/tests/e2e/link_subfolders/data/categorie/headings.md
@@ -4,7 +4,6 @@
 
 All ADR about the headings
 
-
 ## Linked References
 
 * [Do not use numbers in headings](../adr/0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link_subfolders/data/categorie/legal.md
+++ b/tests/e2e/link_subfolders/data/categorie/legal.md
@@ -4,7 +4,6 @@
 
 All ADR about the legal stuff
 
-
 ## Linked References
 
 * [Use CC0 as license](../adr/0001-use-CC0-as-license.md)

--- a/tests/e2e/link_subfolders/data/person/john.md
+++ b/tests/e2e/link_subfolders/data/person/john.md
@@ -4,7 +4,6 @@
 
 Everything that relates to John
 
-
 ## Linked References
 
 * [Do not use numbers in headings](../adr/0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link_subfolders/data/person/person.md
+++ b/tests/e2e/link_subfolders/data/person/person.md
@@ -2,7 +2,6 @@
 
 A list of all the person that worked on the ADR
 
-
 ## Linked References
 
 * [John](john.md)

--- a/tests/e2e/link_subfolders/data/person/richard.md
+++ b/tests/e2e/link_subfolders/data/person/richard.md
@@ -4,7 +4,6 @@
 
 Everything about Richard
 
-
 ## Linked References
 
 * [Use Markdown Architectural Decision Records](../adr/0000-use-markdown-architectural-decision-records.md)

--- a/tests/e2e/link_subfolders/data/person/sophia.md
+++ b/tests/e2e/link_subfolders/data/person/sophia.md
@@ -4,7 +4,6 @@
 
 Everything about Sophia
 
-
 ## Linked References
 
 * [Do not use numbers in headings](../adr/0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link_subfolders/data/status/accepted.md
+++ b/tests/e2e/link_subfolders/data/status/accepted.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are accepted
 
-
 ## Linked References
 
 * [Use CC0 as license](../adr/0001-use-CC0-as-license.md)

--- a/tests/e2e/link_subfolders/data/status/proposed.md
+++ b/tests/e2e/link_subfolders/data/status/proposed.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are proposed
 
-
 ## Linked References
 
 * [Do not use numbers in headings](../adr/0002-do-not-use-numbers-in-headings.md)

--- a/tests/e2e/link_subfolders/data/status/status.md
+++ b/tests/e2e/link_subfolders/data/status/status.md
@@ -2,7 +2,6 @@
 
 List all the status possible for an ADR
 
-
 ## Linked References
 
 * [Accepted](accepted.md)

--- a/tests/e2e/wikilink/data/0000-use-markdown-architectural-decision-records.md
+++ b/tests/e2e/wikilink/data/0000-use-markdown-architectural-decision-records.md
@@ -31,5 +31,4 @@ See also [A rational design process: How and why to fake it](https://doi.org/10.
 * The MADR project is vivid.
 * Version 2.1.2 is the latest one available when starting to document ADRs.
 
-
 ## Linked References

--- a/tests/e2e/wikilink/data/0001-use-CC0-as-license.md
+++ b/tests/e2e/wikilink/data/0001-use-CC0-as-license.md
@@ -22,5 +22,4 @@ We want to have MADR used without any hassle and that users can just go ahead an
 
 Chosen option: "CC0", because this license donates the content to "public domain" and does so as legally as possible.
 
-
 ## Linked References

--- a/tests/e2e/wikilink/data/0002-do-not-use-numbers-in-headings.md
+++ b/tests/e2e/wikilink/data/0002-do-not-use-numbers-in-headings.md
@@ -23,5 +23,4 @@ One does not add numbering manually at the markdown files, but tries to get the 
 * Enables renaming of ADRs (before publication) easily
 * Allows copy'n'paste of ADRs from other repositories without having to worry about the numbers.
 
-
 ## Linked References

--- a/tests/e2e/wikilink/data/accepted.md
+++ b/tests/e2e/wikilink/data/accepted.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are accepted
 
-
 ## Linked References
 
 * [[Use CC0 as license]]

--- a/tests/e2e/wikilink/data/adr.md
+++ b/tests/e2e/wikilink/data/adr.md
@@ -5,7 +5,6 @@ This log lists the architectural decisions for MADR.
 More information on MADR is available at <https://adr.github.io/madr/>.
 General information about architectural decision records is available at <https://adr.github.io/>.
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink/data/categorie.md
+++ b/tests/e2e/wikilink/data/categorie.md
@@ -2,7 +2,6 @@
 
 Every categories of ADR
 
-
 ## Linked References
 
 * [[Format]]

--- a/tests/e2e/wikilink/data/format.md
+++ b/tests/e2e/wikilink/data/format.md
@@ -4,7 +4,6 @@
 
 All ADR about the format
 
-
 ## Linked References
 
 * [[Use Markdown Architectural Decision Records]]

--- a/tests/e2e/wikilink/data/headings.md
+++ b/tests/e2e/wikilink/data/headings.md
@@ -4,7 +4,6 @@
 
 All ADR about the headings
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink/data/john.md
+++ b/tests/e2e/wikilink/data/john.md
@@ -4,7 +4,6 @@
 
 Everything that relates to John
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink/data/legal.md
+++ b/tests/e2e/wikilink/data/legal.md
@@ -4,7 +4,6 @@
 
 All ADR about the legal stuff
 
-
 ## Linked References
 
 * [[Use CC0 as license]]

--- a/tests/e2e/wikilink/data/person.md
+++ b/tests/e2e/wikilink/data/person.md
@@ -2,7 +2,6 @@
 
 A list of all the person that worked on the ADR
 
-
 ## Linked References
 
 * [[John]]

--- a/tests/e2e/wikilink/data/proposed.md
+++ b/tests/e2e/wikilink/data/proposed.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are proposed
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink/data/richard.md
+++ b/tests/e2e/wikilink/data/richard.md
@@ -4,7 +4,6 @@
 
 Everything about Richard
 
-
 ## Linked References
 
 * [[Use Markdown Architectural Decision Records]]

--- a/tests/e2e/wikilink/data/sophia.md
+++ b/tests/e2e/wikilink/data/sophia.md
@@ -4,7 +4,6 @@
 
 Everything about Sophia
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink/data/status.md
+++ b/tests/e2e/wikilink/data/status.md
@@ -2,7 +2,6 @@
 
 List all the status possible for an ADR
 
-
 ## Linked References
 
 * [[Accepted]]

--- a/tests/e2e/wikilink_subfolders/data/adr/0000-use-markdown-architectural-decision-records.md
+++ b/tests/e2e/wikilink_subfolders/data/adr/0000-use-markdown-architectural-decision-records.md
@@ -31,5 +31,4 @@ See also [A rational design process: How and why to fake it](https://doi.org/10.
 * The MADR project is vivid.
 * Version 2.1.2 is the latest one available when starting to document ADRs.
 
-
 ## Linked References

--- a/tests/e2e/wikilink_subfolders/data/adr/0001-use-CC0-as-license.md
+++ b/tests/e2e/wikilink_subfolders/data/adr/0001-use-CC0-as-license.md
@@ -22,5 +22,4 @@ We want to have MADR used without any hassle and that users can just go ahead an
 
 Chosen option: "CC0", because this license donates the content to "public domain" and does so as legally as possible.
 
-
 ## Linked References

--- a/tests/e2e/wikilink_subfolders/data/adr/0002-do-not-use-numbers-in-headings.md
+++ b/tests/e2e/wikilink_subfolders/data/adr/0002-do-not-use-numbers-in-headings.md
@@ -23,5 +23,4 @@ One does not add numbering manually at the markdown files, but tries to get the 
 * Enables renaming of ADRs (before publication) easily
 * Allows copy'n'paste of ADRs from other repositories without having to worry about the numbers.
 
-
 ## Linked References

--- a/tests/e2e/wikilink_subfolders/data/adr/adr.md
+++ b/tests/e2e/wikilink_subfolders/data/adr/adr.md
@@ -5,7 +5,6 @@ This log lists the architectural decisions for MADR.
 More information on MADR is available at <https://adr.github.io/madr/>.
 General information about architectural decision records is available at <https://adr.github.io/>.
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink_subfolders/data/categorie/categorie.md
+++ b/tests/e2e/wikilink_subfolders/data/categorie/categorie.md
@@ -2,7 +2,6 @@
 
 Every categories of ADR
 
-
 ## Linked References
 
 * [[Format]]

--- a/tests/e2e/wikilink_subfolders/data/categorie/format.md
+++ b/tests/e2e/wikilink_subfolders/data/categorie/format.md
@@ -4,7 +4,6 @@
 
 All ADR about the format
 
-
 ## Linked References
 
 * [[Use Markdown Architectural Decision Records]]

--- a/tests/e2e/wikilink_subfolders/data/categorie/headings.md
+++ b/tests/e2e/wikilink_subfolders/data/categorie/headings.md
@@ -4,7 +4,6 @@
 
 All ADR about the headings
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink_subfolders/data/categorie/legal.md
+++ b/tests/e2e/wikilink_subfolders/data/categorie/legal.md
@@ -4,7 +4,6 @@
 
 All ADR about the legal stuff
 
-
 ## Linked References
 
 * [[Use CC0 as license]]

--- a/tests/e2e/wikilink_subfolders/data/person/john.md
+++ b/tests/e2e/wikilink_subfolders/data/person/john.md
@@ -4,7 +4,6 @@
 
 Everything that relates to John
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink_subfolders/data/person/person.md
+++ b/tests/e2e/wikilink_subfolders/data/person/person.md
@@ -2,7 +2,6 @@
 
 A list of all the person that worked on the ADR
 
-
 ## Linked References
 
 * [[John]]

--- a/tests/e2e/wikilink_subfolders/data/person/richard.md
+++ b/tests/e2e/wikilink_subfolders/data/person/richard.md
@@ -4,7 +4,6 @@
 
 Everything about Richard
 
-
 ## Linked References
 
 * [[Use Markdown Architectural Decision Records]]

--- a/tests/e2e/wikilink_subfolders/data/person/sophia.md
+++ b/tests/e2e/wikilink_subfolders/data/person/sophia.md
@@ -4,7 +4,6 @@
 
 Everything about Sophia
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink_subfolders/data/status/accepted.md
+++ b/tests/e2e/wikilink_subfolders/data/status/accepted.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are accepted
 
-
 ## Linked References
 
 * [[Use CC0 as license]]

--- a/tests/e2e/wikilink_subfolders/data/status/proposed.md
+++ b/tests/e2e/wikilink_subfolders/data/status/proposed.md
@@ -4,7 +4,6 @@
 
 List all the ADR that are proposed
 
-
 ## Linked References
 
 * [[Do not use numbers in headings]]

--- a/tests/e2e/wikilink_subfolders/data/status/status.md
+++ b/tests/e2e/wikilink_subfolders/data/status/status.md
@@ -2,7 +2,6 @@
 
 List all the status possible for an ADR
 
-
 ## Linked References
 
 * [[Accepted]]

--- a/tests/unit_tests/adapters/mardown/test_marko_modifier.py
+++ b/tests/unit_tests/adapters/mardown/test_marko_modifier.py
@@ -60,7 +60,7 @@ def test_marko_modifier_nominal_link_system(build_ast, mocked_db):
     modified_ast = modifier.modify_ast(ast, source_note)
 
     # Then
-    assert len(modified_ast.children[10].children[0].children) == 2
+    assert len(modified_ast.children[-1].children[-1].children[0].children) == 2
 
 
 def test_marko_modifier_link_system_url_encode(build_ast, mocked_db):
@@ -104,11 +104,21 @@ def test_marko_modifier_link_system_url_encode(build_ast, mocked_db):
     # - The link to the reference is URL encoded
     # - an already url encoded link is not re-encoded
     assert (
-        modified_ast.children[10].children[0].children[0].children[0].dest
+        modified_ast.children[-1]
+        .children[-1]
+        .children[0]
+        .children[0]
+        .children[0]
+        .dest
         == "digital%20marketing.md"
     )
     assert (
-        modified_ast.children[10].children[1].children[0].children[0].dest
+        modified_ast.children[-1]
+        .children[-1]
+        .children[1]
+        .children[0]
+        .children[0]
+        .dest
         == "content%20marketing.md"
     )
 

--- a/tests/unit_tests/adapters/mardown/test_marko_parser.py
+++ b/tests/unit_tests/adapters/mardown/test_marko_parser.py
@@ -1,17 +1,32 @@
 from unittest.mock import mock_open, patch
 
-from linky_note.adapters.markdown.marko_ext.elements import Wikiimage, Wikilink
+from linky_note.adapters.markdown.marko_ext.elements import (
+    FrontMatter,
+    Wikiimage,
+    Wikilink,
+)
 from linky_note.adapters.markdown.marko_parser import MarkoParserImpl
 from linky_note.dto.dto import ParseConfig
 
-content_links = """# Meeting Note ABC
+content_wikilinks = """# Meeting Note ABC
+
+Wikilinks should work [[Meeting Note]]
+Wikiimage should work ![[image.png]]
+"""
+
+content_frontmatter = """---
+layout: post
+title: Meeting Note ABC
+---
+
+# Meeting Note ABC
 
 Wikilinks should work [[Meeting Note]]
 Wikiimage should work ![[image.png]]
 """
 
 
-@patch("builtins.open", mock_open(read_data=content_links))
+@patch("builtins.open", mock_open(read_data=content_wikilinks))
 def test_parse_filename_nominal():
     # Given: a filename and
     markdown = MarkoParserImpl(ParseConfig(parse_wikilinks=True))
@@ -25,7 +40,7 @@ def test_parse_filename_nominal():
     assert isinstance(result.children[2].children[4], Wikiimage)
 
 
-@patch("builtins.open", mock_open(read_data=content_links))
+@patch("builtins.open", mock_open(read_data=content_wikilinks))
 def test_parse_filename_nominal_deactivate_wikilinks():
     # Given: a filename and
     markdown = MarkoParserImpl(ParseConfig(parse_wikilinks=False))
@@ -40,3 +55,21 @@ def test_parse_filename_nominal_deactivate_wikilinks():
         == "Wikilinks should work [[Meeting Note]]"
     )
     assert isinstance(result.children[2].children[3], Wikiimage)
+
+
+@patch("builtins.open", mock_open(read_data=content_frontmatter))
+def test_parse_filename_nominal_frontmatter():
+    # Given: a filename
+    markdown = MarkoParserImpl(ParseConfig(parse_frontmatter=True))
+    filename = "meeting-note.md"
+
+    # When:
+    result = markdown.parse_file(filename)
+
+    # Then
+    frontmatter = result.children[0]
+    assert isinstance(frontmatter, FrontMatter)
+    assert (
+        frontmatter.children[0].children
+        == "layout: post\ntitle: Meeting Note ABC\n"
+    )


### PR DESCRIPTION
## Description

Support Frontmatter :
- FrontMatter can be parsed
- References can be written in frontmatter instead of in a backlink section

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

